### PR TITLE
Growth split vec migration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-imp-vec"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "`ImpVec` stands for 'immutable-push-vec'. It uses `orx_split_vec::SplitVec` as the underlying data structure, and additionally allows for push/extend operations with an immutable reference."
@@ -9,7 +9,6 @@ repository = "https://github.com/orxfun/orx-imp-vec/"
 keywords = ["vec", "array", "split", "fragments", "pinned"]
 categories = ["data-structures"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-orx-split-vec = "0.1.7"
+orx-split-vec = "0.2.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ categories = ["data-structures"]
 
 
 [dependencies]
-orx-split-vec = "0.2.3"
+orx-split-vec = "^0.2.3"

--- a/src/deref.rs
+++ b/src/deref.rs
@@ -1,15 +1,21 @@
 use crate::ImpVec;
-use orx_split_vec::SplitVec;
+use orx_split_vec::{SplitVec, SplitVecGrowth};
 use std::ops::{Deref, DerefMut};
 
-impl<T> Deref for ImpVec<T> {
-    type Target = SplitVec<T>;
+impl<T, G> Deref for ImpVec<T, G>
+where
+    G: SplitVecGrowth<T>,
+{
+    type Target = SplitVec<T, G>;
     fn deref(&self) -> &Self::Target {
         unsafe { &*self.as_mut_ptr() }
     }
 }
 
-impl<T> DerefMut for ImpVec<T> {
+impl<T, G> DerefMut for ImpVec<T, G>
+where
+    G: SplitVecGrowth<T>,
+{
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe { &mut *self.as_mut_ptr() }
     }

--- a/src/extend.rs
+++ b/src/extend.rs
@@ -1,6 +1,11 @@
+use orx_split_vec::SplitVecGrowth;
+
 use crate::ImpVec;
 
-impl<T: Clone> ImpVec<T> {
+impl<T: Clone, G> ImpVec<T, G>
+where
+    G: SplitVecGrowth<T>,
+{
     /// Clones and appends all elements in a slice to the vec.
     ///
     /// Iterates over the slice `other`, clones each element, and then appends
@@ -29,6 +34,9 @@ impl<T: Clone> ImpVec<T> {
 
         let mut slice = other;
         while !slice.is_empty() {
+            if !self.has_capacity_for_one() {
+                self.add_fragment();
+            }
             let f = fragments.len() - 1;
 
             let last = &mut fragments[f];
@@ -46,7 +54,10 @@ impl<T: Clone> ImpVec<T> {
     }
 }
 
-impl<'a, T: Clone + 'a> ImpVec<T> {
+impl<'a, T: Clone + 'a, G> ImpVec<T, G>
+where
+    G: SplitVecGrowth<T>,
+{
     /// Clones and appends all elements in the iterator to the vec.
     ///
     /// Iterates over the `iter`, clones each element, and then appends

--- a/src/imp_vec.rs
+++ b/src/imp_vec.rs
@@ -1,4 +1,4 @@
-use orx_split_vec::{Fragment, SplitVec};
+use orx_split_vec::{Fragment, LinearGrowth, SplitVec, SplitVecGrowth};
 use std::cell::RefCell;
 
 #[derive(Debug)]
@@ -16,17 +16,25 @@ use std::cell::RefCell;
 ///
 /// This allows to hold on the references of already pushed elements
 /// while building the collection.
-pub struct ImpVec<T> {
-    pub(crate) split_vec: RefCell<SplitVec<T>>,
+pub struct ImpVec<T, G = LinearGrowth>
+where
+    G: SplitVecGrowth<T>,
+{
+    pub(crate) split_vec: RefCell<SplitVec<T, G>>,
 }
 
-impl<T> ImpVec<T> {
-    pub(crate) fn as_mut_ptr(&self) -> *mut SplitVec<T> {
+impl<T, G> ImpVec<T, G>
+where
+    G: SplitVecGrowth<T>,
+{
+    pub(crate) fn as_mut_ptr(&self) -> *mut SplitVec<T, G> {
         self.split_vec.as_ptr()
     }
     pub(crate) fn add_fragment(&self) {
-        let capacity = self.growth.get_capacity(self.fragments().len());
-        let new_fragment = Fragment::new(capacity);
+        let new_fragment = {
+            let capacity = self.growth.new_fragment_capacity(self.fragments());
+            Fragment::new(capacity)
+        };
         unsafe {
             self.split_vec
                 .borrow_mut()
@@ -35,13 +43,21 @@ impl<T> ImpVec<T> {
         }
     }
     pub(crate) fn add_fragment_with_first_value(&self, first_value: T) {
-        let capacity = self.growth.get_capacity(self.fragments().len());
-        let new_fragment = Fragment::new_with_first_value(capacity, first_value);
+        let new_fragment = {
+            let capacity = self.growth.new_fragment_capacity(self.fragments());
+            Fragment::new_with_first_value(capacity, first_value)
+        };
         unsafe {
             self.split_vec
                 .borrow_mut()
                 .fragments_mut()
                 .push(new_fragment);
         }
+    }
+    pub(crate) fn has_capacity_for_one(&self) -> bool {
+        self.fragments()
+            .last()
+            .map(|f| f.has_capacity_for_one())
+            .unwrap_or(false)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,238 @@
-//! `ImpVec` stands for 'immutable-push-vec'.
-//! It uses `orx_split_vec::SplitVec` as the underlying data structure,
-//! and additionally allows for push/extend operations with an immutable reference.
+//! # orx-imp-vec
+//!
+//! An `ImpVec` uses [`SplitVec`](https://crates.io/crates/orx-split-vec) as the underlying data model,
+//! and hence, inherits the following features:
+//!
+//! * vector growth does not require memory copies,
+//! * therefore, growth does not cause the memory locations of elements to change, and
+//! * provides flexible strategies to explicitly define how the vector should grow.
+//!
+//! Additionally, `ImpVec` allows to push to or extend the vector with an immutable reference;
+//! hence, it gets the name `ImpVec`:
+//!
+//! * imp-vec stands for 'immutable push vector',
+//! * and also hints for the little evil behavior it has.
+//!
+//! ## Safety-1
+//!
+//! Pushing to a vector with an immutable reference sounds unsafe;
+//! however, `ImpVec` provides the safety guarantees.
+//!
+//! Consider the following example using `std::vec::Vec` which does not compile:
+//!
+//! ```rust
+//! let mut vec = Vec::with_capacity(2);
+//! vec.extend_from_slice(&[0, 1]);
+//!
+//! let ref0 = &vec[0];
+//! vec.push(2);
+//! // let value0 = *ref0; // does not compile!
+//! ```
+//!
+//! Why does `push` invalidate the reference to the first element which is already pushed to the vector?
+//! * the vector has a capacity of 2; and hence, the push will lead to an expansion of the vector's capacity;
+//! * it is possible that the underlying data will be copied to another place in memory;
+//! * in this case `ref0` will be an invalid reference and dereferencing it would lead to UB.
+
+//! However, `ImpVec` uses the `SplitVec` as its underlying data model
+//! which guarantees that the memory location of an item added to the split vector will never change
+//! unless it is removed from the vector or the vector is dropped.
+//!
+//! Therefore, the  following `ImpVec` version compiles and preserves the validity of the references.
+//!
+//! ```rust
+//! use orx_imp_vec::ImpVec;
+//!
+//! let vec = ImpVec::with_doubling_growth(2);
+//! vec.extend_from_slice(&[0, 1]);
+//!
+//! let ref0 = &vec[0];
+//! let ref0_addr = ref0 as *const i32; // address before growth
+//!
+//! vec.push(2); // capacity is increased here
+//!
+//! let ref0_addr_after_growth = &vec[0] as *const i32; // address after growth
+//! assert_eq!(ref0_addr, ref0_addr_after_growth); // the pushed elements are pinned
+//!
+//! // so it is safe to read from this memory location,
+//! // which will return the correct data
+//! let value0 = *ref0;
+//! assert_eq!(value0, 0);
+//! ```
+//!
+//! ## Safety-2
+//!
+//! On the other hand, the following operations would change the memory locations
+//! of elements of the vector:
+//!
+//! * `insert`ing an element to an arbitrary location of the vector,
+//! * `pop`ping or `remove`ing from the vector, or
+//! * `clear`ing the vector.
+//!
+//! Therefore, similar to `Vec`, these operations require a mutable reference of `ImpVec`.
+//! Thanks to the ownership rules, all references are dropped before using these operations.
+//!
+//! For instance, the following code safely will not compile.
+//!
+//! ```rust
+//! use orx_imp_vec::ImpVec;
+//!
+//! let mut vec = ImpVec::default(); // mut required for the insert call
+//!
+//! // push the first item and hold a reference to it
+//! let ref0 = vec.push_get_ref(0);
+//!
+//! // this is okay
+//! vec.push(1);
+//!
+//! // this operation invalidates `ref0` which is now the address of value 42.
+//! vec.insert(0, 42);
+//! assert_eq!(vec, &[42, 0, 1]);
+//!
+//! // therefore, this line will lead to a compiler error!!
+//! // let value0 = *ref0;
+//! ```
+//!
+//! ## Practicality
+//!
+//! Being able to safely push to a collection with an immutable reference turns out to be very useful.
+//!
+//! You may see below how `ImpVec` helps to easily represent some tricky data structures.
+//!
+//! ### An alternative cons list
+//!
+//! Recall the classical [cons list example](https://doc.rust-lang.org/book/ch15-01-box.html).
+//! Here is the code from the book which would not compile and used to discuss challenges and introduce smart pointers.
+//!
+//! ```ignore
+//! enum List {
+//!     Cons(i32, List),
+//!     Nil,
+//! }
+//! fn main() {
+//!     let list = Cons(1, Cons(2, Cons(3, Nil)));
+//! }
+//! ```
+//!
+//!
+//! Below is a convenient cons list implementation using `ImpVec` as a storage:
+//!
+//! * to which we can immutably push new lists,
+//! * while simultaneously holding onto and using references to already created lists.
+//!
+//! ```rust
+//! use orx_imp_vec::ImpVec;
+//!
+//! enum List<'a, T> {
+//!     Cons(T, &'a List<'a, T>),
+//!     Nil,
+//! }
+//! let storage = ImpVec::default();
+//! let r3 = storage.push_get_ref(List::Cons(3, &List::Nil));   // Cons(3) -> Nil
+//! let r2 = storage.push_get_ref(List::Cons(2, r3));           // Cons(2) -> Cons(3)
+//! let r1 = storage.push_get_ref(List::Cons(2, r2));           // Cons(2) -> Cons(1)
+//! ```
+//!
+//! Alternatively, the `ImpVec` can be used only internally
+//! leading to a cons list implementation with a nice api to build the list.
+//!
+//! The storage will keep growing seamlessly while making sure that
+//! all references are **thin** and **valid**.
+//!
+//! ```rust
+//! use orx_imp_vec::ImpVec;
+//!
+//! enum List<'a, T> {
+//!     Cons(T, &'a List<'a, T>),
+//!     Nil(ImpVec<List<'a, T>>),
+//! }
+//! impl<'a, T> List<'a, T> {
+//!     fn storage(&self) -> &ImpVec<List<'a, T>> {
+//!         match self {
+//!             List::Cons(_, list) => list.storage(),
+//!             List::Nil(storage) => storage,
+//!         }
+//!     }
+//!     pub fn nil() -> Self {
+//!         Self::Nil(ImpVec::default())
+//!     }
+//!     pub fn connect_from(&'a self, value: T) -> &Self {
+//!         let new_list = Self::Cons(value, self);
+//!         self.storage().push_get_ref(new_list)
+//!     }
+//! }
+//!
+//! let nil = List::nil();          // sentinel holds the storage
+//! let r3 = nil.connect_from(3);   // Cons(3) -> Nil
+//! let r2 = r3.connect_from(2);    // Cons(2) -> Cons(3)
+//! let r1 = r2.connect_from(1);    // Cons(2) -> Cons(1)
+//! ```
+//!
+//! ### Directed Acyclic Graph
+//!
+//! The cons list example reveals a pattern;
+//! `ImpVec` can safely store and allow references when the structure is
+//! built backwards starting from a sentinel node.
+//!
+//! Direct acyclic graphs (DAG) or trees are examples for such cases.
+//! In the following, we define the Braess network as an example DAG, having edges:
+//!
+//! * A -> B
+//! * A -> C
+//! * B -> D
+//! * C -> D
+//! * B -> C (the link causing the paradox!)
+//!
+//! Such a graph could very simply constructed with an `ImpVec` where the nodes
+//! are connected via regular references.
+//!
+//! ```rust
+//! use orx_imp_vec::ImpVec;
+//! use std::fmt::{Debug, Display};
+//!
+//! #[derive(PartialEq, Eq, Debug)]
+//! struct Node<'a, T> {
+//!     id: T,
+//!     target_nodes: Vec<&'a Node<'a, T>>,
+//! }
+//! impl<'a, T: Debug + Display> Display for Node<'a, T> {
+//!     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+//!         write!(
+//!             f,
+//!             "node: {}\t\tout-degree={}\tconnected-to={:?}",
+//!             self.id,
+//!             self.target_nodes.len(),
+//!             self.target_nodes.iter().map(|n| &n.id).collect::<Vec<_>>()
+//!         )
+//!     }
+//! }
+//! #[derive(Default)]
+//! struct Graph<'a, T>(ImpVec<Node<'a, T>>);
+//! impl<'a, T> Graph<'a, T> {
+//!     fn add_node(&self, id: T, target_nodes: Vec<&'a Node<'a, T>>) -> &Node<'a, T> {
+//!         let node = Node { id, target_nodes };
+//!         self.0.push_get_ref(node)
+//!     }
+//! }
+//!
+//! let graph = Graph::default();
+//! let d = graph.add_node("D".to_string(), vec![]);
+//! let c = graph.add_node("C".to_string(), vec![d]);
+//! let b = graph.add_node("B".to_string(), vec![c, d]);
+//! let a = graph.add_node("A".to_string(), vec![b, c]);
+//!
+//! for node in graph.0.into_iter() {
+//! println!("{}", node);
+//! }
+//!
+//! assert_eq!(2, a.target_nodes.len());
+//! assert_eq!(vec![b, c], a.target_nodes);
+//! assert_eq!(vec![c, d], a.target_nodes[0].target_nodes);
+//! assert_eq!(vec![d], a.target_nodes[0].target_nodes[0].target_nodes);
+//! assert!(a.target_nodes[0].target_nodes[0].target_nodes[0]
+//!     .target_nodes
+//!     .is_empty());
+//! ```
 
 #![warn(
     missing_docs,

--- a/src/new_imp_vec/new.rs
+++ b/src/new_imp_vec/new.rs
@@ -1,9 +1,237 @@
 use crate::ImpVec;
-use orx_split_vec::{FragmentGrowth, SplitVec};
+use orx_split_vec::{
+    CustomGrowth, DoublingGrowth, ExponentialGrowth, Fragment, LinearGrowth, SplitVec,
+    SplitVecGrowth,
+};
+use std::rc::Rc;
 
-impl<T> ImpVec<T> {
+pub(crate) type GetCapacityOfNewFragment<T> = dyn Fn(&[Fragment<T>]) -> usize;
+
+impl<T, G> ImpVec<T, G>
+where
+    G: SplitVecGrowth<T>,
+{
     /// Creates an empty imp-vector with the given `growth` strategy.
-    pub fn with_growth(growth: FragmentGrowth) -> Self {
+    pub fn with_growth(growth: G) -> Self {
         SplitVec::with_growth(growth).into()
+    }
+}
+
+impl<T> ImpVec<T, LinearGrowth> {
+    /// Creates an imp-vector with linear growth and given `constant_fragment_capacity`.
+    ///
+    /// Assuming it is the common case compared to empty vector scenarios,
+    /// it immediately allocates the first fragment to keep the underlying `SplitVec` struct smaller.
+    ///
+    /// # Panics
+    /// Panics if `constant_fragment_capacity` is zero.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_imp_vec::ImpVec;
+    ///
+    /// // ImpVec<usize, LinearGrowth>
+    /// let vec = ImpVec::with_linear_growth(16);
+    ///
+    /// assert_eq!(1, vec.fragments().len());
+    /// assert_eq!(Some(16), vec.fragments().first().map(|f| f.capacity()));
+    /// assert_eq!(Some(0), vec.fragments().first().map(|f| f.len()));
+    ///
+    /// // push 160 elements
+    /// for i in 0..10 * 16 {
+    ///     vec.push(i);
+    /// }
+    ///
+    /// assert_eq!(10, vec.fragments().len());
+    /// for fragment in vec.fragments() {
+    ///     assert_eq!(16, fragment.len());
+    ///     assert_eq!(16, fragment.capacity());
+    /// }
+    ///
+    /// // push the 161-st element
+    /// vec.push(42);
+    /// assert_eq!(11, vec.fragments().len());
+    /// assert_eq!(Some(16), vec.fragments().last().map(|f| f.capacity()));
+    /// assert_eq!(Some(1), vec.fragments().last().map(|f| f.len()));
+    /// ```
+    pub fn with_linear_growth(constant_fragment_capacity: usize) -> Self {
+        assert!(constant_fragment_capacity > 0);
+        SplitVec::with_linear_growth(constant_fragment_capacity).into()
+    }
+}
+
+impl<T> ImpVec<T, DoublingGrowth> {
+    /// Creates an imp-vector with doubling growth
+    /// which creates a fragment with double the capacity
+    /// of the prior fragment every time the split vector needs to expand.
+    ///
+    /// Assuming it is the common case compared to empty vector scenarios,
+    /// it immediately allocates the first fragment to keep the underlying `SplitVec` struct smaller.
+    ///
+    /// # Panics
+    /// Panics if `first_fragment_capacity` is zero.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_imp_vec::ImpVec;
+    ///
+    /// // ImpVec<usize, DoublingGrowth>
+    /// let vec = ImpVec::with_doubling_growth(2);
+    ///
+    /// assert_eq!(1, vec.fragments().len());
+    /// assert_eq!(Some(2), vec.fragments().first().map(|f| f.capacity()));
+    /// assert_eq!(Some(0), vec.fragments().first().map(|f| f.len()));
+    ///
+    /// // fill the first 5 fragments
+    /// let expected_fragment_capacities = vec![2, 4, 8, 16, 32];
+    /// let num_items: usize = expected_fragment_capacities.iter().sum();
+    /// for i in 0..num_items {
+    ///     vec.push(i);
+    /// }
+    ///
+    /// assert_eq!(
+    ///     expected_fragment_capacities,
+    ///     vec.fragments()
+    ///     .iter()
+    ///     .map(|f| f.capacity())
+    ///     .collect::<Vec<_>>()
+    /// );
+    /// assert_eq!(
+    ///     expected_fragment_capacities,
+    ///     vec.fragments().iter().map(|f| f.len()).collect::<Vec<_>>()
+    /// );
+    ///
+    /// // create the 6-th fragment doubling the capacity
+    /// vec.push(42);
+    /// assert_eq!(
+    ///     vec.fragments().len(),
+    ///     expected_fragment_capacities.len() + 1
+    /// );
+    ///
+    /// assert_eq!(vec.fragments().last().map(|f| f.capacity()), Some(32 * 2));
+    /// assert_eq!(vec.fragments().last().map(|f| f.len()), Some(1));
+    /// ```
+    pub fn with_doubling_growth(first_fragment_capacity: usize) -> Self {
+        assert!(first_fragment_capacity > 0);
+        SplitVec::with_doubling_growth(first_fragment_capacity).into()
+    }
+}
+
+impl<T> ImpVec<T, ExponentialGrowth> {
+    /// Creates an imp-vector which allows new fragments grow exponentially.
+    ///
+    /// The capacity of the n-th fragment is computed as
+    /// `cap0 * pow(growth_coefficient, n)`
+    /// where `cap0` is the capacity of the first fragment.
+    ///
+    /// Note that `DoublingGrowth` is a special case of `ExponentialGrowth`
+    /// with `growth_coefficient` equal to 2,
+    /// while providing a faster access by index.
+    ///
+    /// On the other hand, exponential growth allows for fitting growth strategies
+    /// for fitting situations which could be a better choice when memory allocation
+    /// is more important than index access complexity.
+    ///
+    /// As you may see in the example below, it is especially useful in providing
+    /// exponential growth rates slower than the doubling.
+    ///
+    /// Assuming it is the common case compared to empty vector scenarios,
+    /// it immediately allocates the first fragment to keep the `SplitVec` struct smaller.
+    ///
+    /// # Panics
+    /// Panics if `first_fragment_capacity` is zero,
+    /// or if `growth_coefficient` is less than 1.0.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_imp_vec::ImpVec;
+    ///
+    /// // SplitVec<usize, ExponentialGrowth>
+    /// let mut vec = ImpVec::with_exponential_growth(2, 1.5);
+    ///
+    /// assert_eq!(1, vec.fragments().len());
+    /// assert_eq!(Some(2), vec.fragments().first().map(|f| f.capacity()));
+    /// assert_eq!(Some(0), vec.fragments().first().map(|f| f.len()));
+    ///
+    /// // fill the first 5 fragments
+    /// let expected_fragment_capacities = vec![2, 3, 4, 6, 9, 13];
+    /// let num_items: usize = expected_fragment_capacities.iter().sum();
+    /// for i in 0..num_items {
+    ///     vec.push(i);
+    /// }
+    ///
+    /// assert_eq!(
+    ///     expected_fragment_capacities,
+    ///     vec.fragments()
+    ///     .iter()
+    ///     .map(|f| f.capacity())
+    ///     .collect::<Vec<_>>()
+    /// );
+    /// assert_eq!(
+    ///     expected_fragment_capacities,
+    ///     vec.fragments().iter().map(|f| f.len()).collect::<Vec<_>>()
+    /// );
+    ///
+    /// // create the 6-th fragment doubling the capacity
+    /// vec.push(42);
+    /// assert_eq!(
+    ///     vec.fragments().len(),
+    ///     expected_fragment_capacities.len() + 1
+    /// );
+    ///
+    /// assert_eq!(vec.fragments().last().map(|f| f.capacity()), Some((13 as f32 * 1.5) as usize));
+    /// assert_eq!(vec.fragments().last().map(|f| f.len()), Some(1));
+    /// ```
+    pub fn with_exponential_growth(
+        first_fragment_capacity: usize,
+        growth_coefficient: f32,
+    ) -> Self {
+        assert!(first_fragment_capacity > 0);
+        assert!(growth_coefficient >= 1.0);
+        SplitVec::with_exponential_growth(first_fragment_capacity, growth_coefficient).into()
+    }
+}
+
+impl<T> ImpVec<T, CustomGrowth<T>> {
+    /// Creates an imp vector with the custom grwoth strategy
+    /// defined by the function `get_capacity_of_new_fragment`.
+    ///
+    /// # Examples
+    /// ```
+    /// use orx_split_vec::Fragment;
+    /// use orx_imp_vec::ImpVec;
+    /// use std::rc::Rc;
+    ///
+    /// // vec: SplitVec<usize, CustomGrowth<usize>>
+    /// let vec =
+    ///     ImpVec::with_custom_growth_function(Rc::new(|fragments: &[Fragment<_>]| {
+    ///         if fragments.len() % 2 == 0 {
+    ///             2
+    ///         } else {
+    ///             8
+    ///         }
+    ///     }));
+    ///
+    ///     for i in 0..100 {
+    ///         vec.push(i);
+    ///     }
+    ///
+    ///     vec.into_iter().zip(0..100).all(|(l, r)| *l == r);
+    ///     
+    ///     for (f, fragment) in vec.fragments().iter().enumerate() {
+    ///         if f % 2 == 0 {
+    ///             assert_eq!(2, fragment.capacity());
+    ///         } else {
+    ///             assert_eq!(8, fragment.capacity());
+    ///         }
+    ///     }
+    /// ```
+    pub fn with_custom_growth_function(
+        get_capacity_of_new_fragment: Rc<GetCapacityOfNewFragment<T>>,
+    ) -> Self {
+        SplitVec::with_custom_growth_function(get_capacity_of_new_fragment).into()
     }
 }


### PR DESCRIPTION
Refactored to include `SplitVecGrowth` as a generic type parameter.