### PR TITLE
orx-pinned-vec version updated to 2.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-imp-vec"
-version = "2.0.2"
+version = "2.1.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "`ImpVec`, standing for immutable push vector 👿, is a data structure which allows appending elements with a shared reference."
@@ -10,5 +10,5 @@ keywords = ["vec", "pinned", "bag", "container", "split"]
 categories = ["data-structures", "rust-patterns"]
 
 [dependencies]
-orx-pinned-vec = "2.1"
-orx-split-vec = "2.1"
+orx-pinned-vec = "2.7"
+orx-split-vec = "2.8"

--- a/src/common_traits/debug.rs
+++ b/src/common_traits/debug.rs
@@ -19,10 +19,7 @@ mod tests {
         let vec = ImpVec::new();
         vec.imp_extend_from_slice(&['a', 'b', 'c']);
 
-        let debug_str = format!("{:?}", &vec);
-        assert_eq!(
-            debug_str,
-            "ImpVec { pinned_vec: SplitVec [\n    ['a', 'b', 'c']\n]\n }"
-        );
+        let expected_debug_str = format!("ImpVec {{ pinned_vec: {:?} }}", &vec.pinned_vec);
+        assert_eq!(expected_debug_str, format!("{:?}", &vec));
     }
 }

--- a/src/common_traits/deref_derefmut.rs
+++ b/src/common_traits/deref_derefmut.rs
@@ -5,13 +5,13 @@ use std::ops::{Deref, DerefMut};
 impl<T, P: PinnedVec<T>> Deref for ImpVec<T, P> {
     type Target = P;
     fn deref(&self) -> &Self::Target {
-        &self.pinned_vec
+        self.pinned_mut()
     }
 }
 
 impl<T, P: PinnedVec<T>> DerefMut for ImpVec<T, P> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.pinned_vec
+        self.pinned_mut()
     }
 }
 
@@ -25,7 +25,7 @@ mod tests {
         vec.imp_extend_from_slice(&['a', 'b', 'c']);
 
         let pinned_deref = vec.deref();
-        assert_eq!(pinned_deref, &vec.pinned_vec);
+        assert_eq!(pinned_deref, vec.pinned_mut());
     }
 
     #[test]

--- a/src/common_traits/from.rs
+++ b/src/common_traits/from.rs
@@ -4,8 +4,8 @@ use orx_pinned_vec::PinnedVec;
 impl<T, P: PinnedVec<T>> From<P> for ImpVec<T, P> {
     fn from(pinned_vec: P) -> Self {
         Self {
-            pinned_vec,
-            _phantom: Default::default(),
+            pinned_vec: pinned_vec.into(),
+            phantom: Default::default(),
         }
     }
 }


### PR DESCRIPTION
* Also `UnsafeCell` is made use of to model interior mutability of the imp vec.