### PR TITLE
no-std-support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "orx-imp-vec"
-version = "2.6.0"
+version = "2.7.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
-description = "`ImpVec`, standing for immutable push vector 👿, is a data structure which allows appending elements with a shared reference."
+description = "`ImpVec`, stands for immutable push vector 👿, is a data structure which allows appending elements with a shared reference."
 license = "MIT"
 repository = "https://github.com/orxfun/orx-imp-vec/"
 keywords = ["vec", "pinned", "bag", "container", "split"]
-categories = ["data-structures", "rust-patterns"]
+categories = ["data-structures", "rust-patterns", "no-std"]
 
 [dependencies]
-orx-pseudo-default = "1.2"
-orx-pinned-vec = "3.3"
-orx-fixed-vec = "3.3"
-orx-split-vec = "3.3"
+orx-pseudo-default = { version = "1.4", default-features = false }
+orx-pinned-vec = "3.9"
+orx-fixed-vec = "3.9"
+orx-split-vec = "3.9"

--- a/README.md
+++ b/README.md
@@ -3,21 +3,201 @@
 [![orx-imp-vec crate](https://img.shields.io/crates/v/orx-imp-vec.svg)](https://crates.io/crates/orx-imp-vec)
 [![orx-imp-vec documentation](https://docs.rs/orx-imp-vec/badge.svg)](https://docs.rs/orx-imp-vec)
 
-`ImpVec`, standing for immutable push vector 👿, is a data structure which allows appending elements with a shared reference.
+`ImpVec`, stands for immutable push vector 👿, is a data structure which allows appending elements with a shared reference.
 
 Specifically, it extends vector capabilities with the following two methods:
-* `fn imp_push(&self, value: T)`
-* `fn imp_extend_from_slice(&self, slice: &[T])`
+* [`fn imp_push(&self, value: T)`](https://docs.rs/orx-imp-vec/latest/orx_imp_vec/struct.ImpVec.html#method.imp_push)
+* [`fn imp_extend_from_slice(&self, slice: &[T])`](https://docs.rs/orx-imp-vec/latest/orx_imp_vec/struct.ImpVec.html#method.imp_extend_from_slice)
 
 Note that both of these methods can be called with `&self` rather than `&mut self`.
 
-# Motivation
+## Motivation
 
-Appending to a vector with a shared reference sounds unconventional, and it is. However, if we consider our vector as a bag of or a container of things rather than having a collective meaning; then, appending element or elements to the end of the vector:
-* does not mutate any of already added elements, and hence,
-* **it is not different than creating a new element in the scope**.
+Appending to a vector with a shared reference sounds unconventional, and it is.
 
-# Safety
+From another perspective, however, appending an element to the end of the vector does not mutate any of already added elements or change their positions. It can be argued that *it is not different than creating a new element within the scope*. This statement will be clear with the following example.
+
+The challenge is to define a type-safe, recursive and expressive expression builder. In our toy example, an expression can either be a symbol, or addition or subtraction of two expressions. The final desired ergonomic solution is as follows:
+
+```rust ignore
+let scope = Scope::default();
+
+// instantiate some symbols
+let x = scope.symbol("x");
+let y = scope.symbol("y");
+assert_eq!(&x.to_string(), "x");
+assert_eq!(&y.to_string(), "y");
+
+// apply binary operations to create new symbols
+let p = x + y;
+assert_eq!(&p.to_string(), "x + y");
+
+let q = x - y;
+assert_eq!(&q.to_string(), "x - y");
+
+// and further binary operations
+let t = p + q;
+assert_eq!(&t.to_string(), "x + y + x - y");
+
+// we only use 'scope' to create symbols
+// but in the background, all expressions are collected in our scope
+let all_expressions: Vec<_> = scope.expressions.iter().map(|x| x.to_string()).collect();
+assert_eq!(
+    all_expressions,
+    ["x", "y", "x + y", "x - y", "x + y + x - y"]
+);
+```
+
+This at first seemed **impossible in safe rust** for way too many reasons. However, it is conveniently possible using an `ImpVec`. You may run the example in [expressions.rs](https://github.com/orxfun/orx-imp-vec/blob/main/examples/expressions.rs) by `cargo run --example expressions`, or see the details of the implementation below.
+
+<details>
+<summary style="font-weight:bold;">Complete Implementation</summary>
+
+```rust
+use orx_imp_vec::*;
+use std::{
+    fmt::Display,
+    ops::{Add, Sub},
+};
+
+/// A scope for expressions.
+#[derive(Default)]
+struct Scope<'a> {
+    expressions: ImpVec<Expr<'a>>,
+}
+
+impl<'a> Scope<'a> {
+    /// Bottom of the expressions recursion, the symbol primitive
+    fn symbol(&'a self, name: &'static str) -> ExprInScope<'a> {
+        let expr = Expr::Symbol(name);
+        self.expressions.imp_push(expr);
+        ExprInScope {
+            scope: self,
+            expr: &self.expressions[self.expressions.len() - 1],
+        }
+    }
+}
+
+/// A recursive expression with three demo variants
+enum Expr<'a> {
+    Symbol(&'static str),
+    Addition(&'a Expr<'a>, &'a Expr<'a>),
+    Subtraction(&'a Expr<'a>, &'a Expr<'a>),
+}
+
+impl<'a> Display for Expr<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Expr::Symbol(x) => write!(f, "{}", x),
+            Expr::Addition(x, y) => write!(f, "{} + {}", x, y),
+            Expr::Subtraction(x, y) => write!(f, "{} - {}", x, y),
+        }
+    }
+}
+
+/// Expression in a scope:
+/// * it knows what it is
+/// * it knows which scope it belongs to
+///
+/// It can implement Copy which turns out to be extremely important!
+#[derive(Clone, Copy)]
+struct ExprInScope<'a> {
+    scope: &'a Scope<'a>,
+    expr: &'a Expr<'a>,
+}
+
+impl<'a> ExprInScope<'a> {
+    /// Recall, it knows that scope it belongs to,
+    /// and can check it in O(1)
+    fn belongs_to_same_scope(&self, other: Self) -> bool {
+        let self_scope = self.scope as *const Scope;
+        let other_scope = other.scope as *const Scope;
+        self_scope == other_scope
+    }
+}
+impl<'a> Display for ExprInScope<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.expr)
+    }
+}
+
+impl<'a> Add for ExprInScope<'a> {
+    type Output = ExprInScope<'a>;
+
+    /// We can create an expression by adding two expressions
+    ///
+    /// Where do we store the new expression?
+    ///
+    /// Of course, in the scope that both expressions belong to.
+    /// And we can do so by `imp_push`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the lhs & rhs do not belong to the same scope.
+    fn add(self, rhs: Self) -> Self::Output {
+        assert!(self.belongs_to_same_scope(rhs));
+        let expressions = &self.scope.expressions;
+        let expr = Expr::Addition(self.expr, rhs.expr);
+        expressions.imp_push(expr);
+        ExprInScope {
+            scope: self.scope,
+            expr: &expressions[expressions.len() - 1],
+        }
+    }
+}
+
+impl<'a> Sub for ExprInScope<'a> {
+    type Output = ExprInScope<'a>;
+
+    /// Similarly, we can create an expression by subtracting two expressions
+    /// 
+    /// # Panics
+    ///
+    /// Panics if the lhs & rhs do not belong to the same scope.
+    fn sub(self, rhs: Self) -> Self::Output {
+        assert!(self.belongs_to_same_scope(rhs));
+        let expressions = &self.scope.expressions;
+        let expr = Expr::Subtraction(self.expr, rhs.expr);
+        expressions.imp_push(expr);
+        ExprInScope {
+            scope: self.scope,
+            expr: &expressions[expressions.len() - 1],
+        }
+    }
+}
+
+let scope = Scope::default();
+
+// instantiate some symbols
+let x = scope.symbol("x");
+let y = scope.symbol("y");
+assert_eq!(&x.to_string(), "x");
+assert_eq!(&y.to_string(), "y");
+
+// apply binary operations to create new symbols
+let p = x + y;
+assert_eq!(&p.to_string(), "x + y");
+
+let q = x - y;
+assert_eq!(&q.to_string(), "x - y");
+
+// and further binary operations
+let t = p + q;
+assert_eq!(&t.to_string(), "x + y + x - y");
+
+// we only use 'scope' to create symbols
+// but in the background, all expressions are collected in our scope
+let all_expressions: Vec<_> = scope.expressions.iter().map(|x| x.to_string()).collect();
+assert_eq!(
+    all_expressions,
+    ["x", "y", "x + y", "x - y", "x + y + x - y"]
+);
+```
+
+</details>
+
+
+## Safety
 
 It is natural to expect that appending elements to a vector does not affect already added elements. However, this is usually not the case due to underlying memory management. For instance, `std::vec::Vec` may move already added elements to different memory locations to maintain the contagious layout of the vector. 
 
@@ -37,10 +217,10 @@ vec.push(4);
 // assert_eq!(ref_to_first, &0);
 ```
 
-This beloved feature of the borrow checker of rust is not required and used for `imp_push` and `imp_extend_from_slice` methods of `ImpVec` since these methods do not require a `&mut self` reference. Therefore, the following code compiles and runs perfectly safely.
+This beloved feature of the borrow checker of rust is not required for `imp_push` and `imp_extend_from_slice` methods of `ImpVec` since these methods do not require a `&mut self` reference. Therefore, the following code compiles and runs perfectly safely.
 
 ```rust
-use orx_imp_vec::prelude::*;
+use orx_imp_vec::*;
 
 let mut vec = ImpVec::new();
 vec.extend_from_slice(&[0, 1, 2, 3]);

--- a/examples/bag_of_things.rs
+++ b/examples/bag_of_things.rs
@@ -1,0 +1,80 @@
+use orx_imp_vec::*;
+
+#[derive(Default)]
+struct Bag {
+    things: ImpVec<Thing>,
+}
+
+impl Bag {
+    fn push_thing(&self, name: &str) -> ThingInBag {
+        self.things.imp_push(Thing {
+            name: name.to_string(),
+        });
+        ThingInBag {
+            bag: self,
+            thing: &self.things[self.things.len() - 1],
+        }
+    }
+
+    fn things(&self) -> Vec<&str> {
+        self.things.iter().map(|x| x.name.as_str()).collect()
+    }
+}
+
+struct Thing {
+    name: String,
+}
+
+#[derive(Clone, Copy)]
+struct ThingInBag<'a> {
+    thing: &'a Thing,
+    bag: &'a Bag,
+}
+impl<'a> ThingInBag<'a> {
+    fn push_thing_in_same_bag(&self, name: &str) -> ThingInBag {
+        self.bag.push_thing(name)
+    }
+
+    fn is_in_bag(&self, bag: &Bag) -> bool {
+        let self_bag = self.bag as *const Bag;
+        let other_bag = bag as *const Bag;
+        self_bag == other_bag
+    }
+}
+impl<'a> PartialEq for ThingInBag<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        let same_bag = self.bag as *const Bag == other.bag as *const Bag;
+        let same_thing = self.thing as *const Thing == other.thing as *const Thing;
+        same_bag && same_thing
+    }
+}
+
+fn main() {
+    // create a bag
+    let bag = Bag::default();
+
+    // add things and collect things in bag
+    let pen = bag.push_thing("pen");
+    let cup = bag.push_thing("cup");
+    assert_eq!(bag.things(), ["pen", "cup"]);
+
+    // add new things to bag using existing things in bag
+    pen.push_thing_in_same_bag("pencil");
+    cup.push_thing_in_same_bag("cupcake");
+    assert_eq!(bag.things(), ["pen", "cup", "pencil", "cupcake"]);
+
+    // create another bag
+    let other_bag = Bag::default();
+    let key = other_bag.push_thing("key");
+    let other_pen = other_bag.push_thing("pen");
+
+    // check if things belong to the same bag in constant time
+    assert_eq!(pen.is_in_bag(&bag), true);
+    assert_eq!(pen.is_in_bag(&other_bag), false);
+
+    assert_eq!(key.is_in_bag(&bag), false);
+    assert_eq!(key.is_in_bag(&other_bag), true);
+
+    // use referential equality to compare if two things are the same
+    assert!(pen != other_pen);
+}

--- a/examples/expressions.rs
+++ b/examples/expressions.rs
@@ -1,0 +1,145 @@
+use orx_imp_vec::*;
+use std::{
+    fmt::Display,
+    ops::{Add, Sub},
+};
+
+/// A scope for expressions.
+#[derive(Default)]
+struct Scope<'a> {
+    expressions: ImpVec<Expr<'a>>,
+}
+
+impl<'a> Scope<'a> {
+    /// Bottom of the expressions recursion, the symbol primitive
+    fn symbol(&'a self, name: &'static str) -> ExprInScope<'a> {
+        let expr = Expr::Symbol(name);
+        self.expressions.imp_push(expr);
+        ExprInScope {
+            scope: self,
+            expr: &self.expressions[self.expressions.len() - 1],
+        }
+    }
+}
+
+/// A recursive expression with three demo variants
+enum Expr<'a> {
+    Symbol(&'static str),
+    Addition(&'a Expr<'a>, &'a Expr<'a>),
+    Subtraction(&'a Expr<'a>, &'a Expr<'a>),
+}
+
+impl<'a> Display for Expr<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Expr::Symbol(x) => write!(f, "{}", x),
+            Expr::Addition(x, y) => write!(f, "{} + {}", x, y),
+            Expr::Subtraction(x, y) => write!(f, "{} - {}", x, y),
+        }
+    }
+}
+
+/// Expression in a scope:
+/// * it knows what it is
+/// * it knows which scope it belongs to
+///
+/// It can implement Copy which turns out to be extremely important!
+#[derive(Clone, Copy)]
+struct ExprInScope<'a> {
+    scope: &'a Scope<'a>,
+    expr: &'a Expr<'a>,
+}
+
+impl<'a> ExprInScope<'a> {
+    /// Recall, it knows that scope it belongs to,
+    /// and can check it in O(1)
+    fn belongs_to_same_scope(&self, other: Self) -> bool {
+        let self_scope = self.scope as *const Scope;
+        let other_scope = other.scope as *const Scope;
+        self_scope == other_scope
+    }
+}
+impl<'a> Display for ExprInScope<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.expr)
+    }
+}
+
+impl<'a> Add for ExprInScope<'a> {
+    type Output = ExprInScope<'a>;
+
+    /// We can create an expression by adding two expressions
+    ///
+    /// Where do we store the new expression?
+    ///
+    /// Of course, in the scope that both expressions belong to.
+    /// And we can do so by `imp_push`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the lhs & rhs do not belong to the same scope.
+    fn add(self, rhs: Self) -> Self::Output {
+        assert!(self.belongs_to_same_scope(rhs));
+        let expressions = &self.scope.expressions;
+        let expr = Expr::Addition(self.expr, rhs.expr);
+        expressions.imp_push(expr);
+        ExprInScope {
+            scope: self.scope,
+            expr: &expressions[expressions.len() - 1],
+        }
+    }
+}
+
+impl<'a> Sub for ExprInScope<'a> {
+    type Output = ExprInScope<'a>;
+
+    /// Similarly, we can create an expression by subtracting two expressions
+    ///
+    /// Where do we store the new expression?
+    ///
+    /// Of course, in the scope that both expressions belong to.
+    /// And we can do so by `imp_push`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the lhs & rhs do not belong to the same scope.
+    fn sub(self, rhs: Self) -> Self::Output {
+        assert!(self.belongs_to_same_scope(rhs));
+        let expressions = &self.scope.expressions;
+        let expr = Expr::Subtraction(self.expr, rhs.expr);
+        expressions.imp_push(expr);
+        ExprInScope {
+            scope: self.scope,
+            expr: &expressions[expressions.len() - 1],
+        }
+    }
+}
+
+fn main() {
+    let scope = Scope::default();
+
+    // instantiate some symbols
+    let x = scope.symbol("x");
+    let y = scope.symbol("y");
+    assert_eq!(&x.to_string(), "x");
+    assert_eq!(&y.to_string(), "y");
+
+    // apply binary operations to create new symbols
+    let p = x + y;
+    assert_eq!(&p.to_string(), "x + y");
+
+    let q = x - y;
+    assert_eq!(&q.to_string(), "x - y");
+
+    // and further binary operations
+    let t = p + q;
+    assert_eq!(&t.to_string(), "x + y + x - y");
+
+    // we only use 'scope' to create symbols
+    // but in the background, all expressions are collected in our scope
+    let all_expressions: Vec<_> = scope.expressions.iter().map(|x| x.to_string()).collect();
+    assert_eq!(
+        all_expressions,
+        ["x", "y", "x + y", "x - y", "x + y + x - y"]
+    );
+}

--- a/src/common_traits/debug.rs
+++ b/src/common_traits/debug.rs
@@ -1,12 +1,17 @@
 use crate::imp_vec::ImpVec;
+use core::fmt::Debug;
 use orx_pinned_vec::PinnedVec;
-use std::fmt::Debug;
 
-impl<T, P: PinnedVec<T> + Debug> Debug for ImpVec<T, P> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let pinned_vec = unsafe { &*self.pinned_vec.get() };
-        f.debug_struct("ImpVec")
-            .field("pinned_vec", &pinned_vec)
-            .finish()
+impl<T: Debug, P: PinnedVec<T> + Debug> Debug for ImpVec<T, P> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "[")?;
+        let mut iter = self.iter();
+        if let Some(x) = iter.next() {
+            write!(f, "{:?}", x)?;
+            for x in iter {
+                write!(f, ", {:?}", x)?;
+            }
+        }
+        write!(f, "]")
     }
 }

--- a/src/common_traits/deref_derefmut.rs
+++ b/src/common_traits/deref_derefmut.rs
@@ -1,6 +1,6 @@
 use crate::imp_vec::ImpVec;
+use core::ops::{Deref, DerefMut};
 use orx_pinned_vec::PinnedVec;
-use std::ops::{Deref, DerefMut};
 
 impl<T, P: PinnedVec<T>> Deref for ImpVec<T, P> {
     type Target = P;

--- a/src/common_traits/eq.rs
+++ b/src/common_traits/eq.rs
@@ -1,4 +1,5 @@
 use crate::imp_vec::ImpVec;
+use alloc::vec::Vec;
 use orx_fixed_vec::FixedVec;
 use orx_pinned_vec::PinnedVec;
 use orx_split_vec::{Growth, SplitVec};

--- a/src/common_traits/index.rs
+++ b/src/common_traits/index.rs
@@ -1,0 +1,21 @@
+use crate::imp_vec::ImpVec;
+use core::ops::{Index, IndexMut};
+use orx_pinned_vec::PinnedVec;
+
+const OOB: &str = "out-of-bounds";
+
+impl<T, P: PinnedVec<T>> Index<usize> for ImpVec<T, P> {
+    type Output = T;
+
+    #[inline(always)]
+    fn index(&self, index: usize) -> &Self::Output {
+        self.get(index).expect(OOB)
+    }
+}
+
+impl<T, P: PinnedVec<T>> IndexMut<usize> for ImpVec<T, P> {
+    #[inline(always)]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        self.get_mut(index).expect(OOB)
+    }
+}

--- a/src/common_traits/into_iter.rs
+++ b/src/common_traits/into_iter.rs
@@ -1,4 +1,5 @@
-use crate::prelude::*;
+use crate::ImpVec;
+use orx_pinned_vec::PinnedVec;
 
 impl<T, P: PinnedVec<T>> IntoIterator for ImpVec<T, P> {
     type Item = T;

--- a/src/common_traits/mod.rs
+++ b/src/common_traits/mod.rs
@@ -3,4 +3,5 @@ mod deref_derefmut;
 mod eq;
 mod from;
 mod from_iter;
+mod index;
 mod into_iter;

--- a/src/imp_vec.rs
+++ b/src/imp_vec.rs
@@ -1,6 +1,6 @@
+use core::{cell::UnsafeCell, marker::PhantomData};
 use orx_pinned_vec::PinnedVec;
 use orx_split_vec::SplitVec;
-use std::{cell::UnsafeCell, marker::PhantomData};
 
 /// `ImpVec`, standing for immutable push vector 👿, is a data structure which allows appending elements with a shared reference.
 ///
@@ -47,7 +47,7 @@ use std::{cell::UnsafeCell, marker::PhantomData};
 /// Therefore, the following code compiles and runs perfectly safely.
 ///
 /// ```rust
-/// use orx_imp_vec::prelude::*;
+/// use orx_imp_vec::*;
 ///
 /// let mut vec = ImpVec::new();
 /// vec.extend_from_slice(&[0, 1, 2, 3]);
@@ -99,7 +99,7 @@ impl<T, P: PinnedVec<T>> ImpVec<T, P> {
     /// # Example
     ///
     /// ```rust
-    /// use orx_imp_vec::prelude::*;
+    /// use orx_imp_vec::*;
     ///
     /// let mut vec = ImpVec::new();
     ///
@@ -149,7 +149,7 @@ impl<T, P: PinnedVec<T>> ImpVec<T, P> {
     /// Therefore, the following code compiles and runs perfectly safely.
     ///
     /// ```rust
-    /// use orx_imp_vec::prelude::*;
+    /// use orx_imp_vec::*;
     ///
     /// let mut vec = ImpVec::new();
     /// vec.extend_from_slice(&[0, 1, 2, 3]);
@@ -178,7 +178,7 @@ impl<T, P: PinnedVec<T>> ImpVec<T, P> {
     /// # Example
     ///
     /// ```rust
-    /// use orx_imp_vec::prelude::*;
+    /// use orx_imp_vec::*;
     ///
     /// let mut vec = ImpVec::new();
     ///
@@ -229,7 +229,7 @@ impl<T, P: PinnedVec<T>> ImpVec<T, P> {
     /// Therefore, the following code compiles and runs perfectly safely.
     ///
     /// ```rust
-    /// use orx_imp_vec::prelude::*;
+    /// use orx_imp_vec::*;
     ///
     /// let mut vec = ImpVec::new();
     /// vec.push(0);
@@ -269,7 +269,7 @@ impl<T> Default for ImpVec<T> {
     /// # Example
     ///
     /// ```rust
-    /// use orx_imp_vec::prelude::*;
+    /// use orx_imp_vec::*;
     ///
     /// let imp_vec: ImpVec<usize> = ImpVec::default();
     /// assert!(imp_vec.is_empty());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,70 +1,4 @@
-//! # orx-imp-vec
-//!
-//! [![orx-imp-vec crate](https://img.shields.io/crates/v/orx-imp-vec.svg)](https://crates.io/crates/orx-imp-vec)
-//! [![orx-imp-vec documentation](https://docs.rs/orx-imp-vec/badge.svg)](https://docs.rs/orx-imp-vec)
-//!
-//! `ImpVec`, standing for immutable push vector 👿, is a data structure which allows appending elements with a shared reference.
-//!
-//! Specifically, it extends vector capabilities with the following two methods:
-//! * `fn imp_push(&self, value: T)`
-//! * `fn imp_extend_from_slice(&self, slice: &[T])`
-//!
-//! Note that both of these methods can be called with `&self` rather than `&mut self`.
-//!
-//! # Motivation
-//!
-//! Appending to a vector with a shared reference sounds unconventional, and it is. However, if we consider our vector as a bag of or a container of things rather than having a collective meaning; then, appending element or elements to the end of the vector:
-//! * does not mutate any of already added elements, and hence,
-//! * **it is not different than creating a new element in the scope**.
-//!
-//! # Safety
-//!
-//! It is natural to expect that appending elements to a vector does not affect already added elements. However, this is usually not the case due to underlying memory management. For instance, `std::vec::Vec` may move already added elements to different memory locations to maintain the contagious layout of the vector.
-//!
-//! [`PinnedVec`](https://crates.io/crates/orx-pinned-vec) prevents such implicit changes in memory locations. It guarantees that push and extend methods keep memory locations of already added elements intact. Therefore, it is perfectly safe to hold on to references of the vector while appending elements.
-//!
-//! Consider the classical example that does not compile, which is often presented to highlight the safety guarantees of rust:
-//!
-//! ```rust
-//! let mut vec = vec![0, 1, 2, 3];
-//!
-//! let ref_to_first = &vec[0];
-//! assert_eq!(ref_to_first, &0);
-//!
-//! vec.push(4);
-//!
-//! // does not compile due to the following reason:  cannot borrow `vec` as mutable because it is also borrowed as immutable
-//! // assert_eq!(ref_to_first, &0);
-//! ```
-//!
-//! This beloved feature of the borrow checker of rust is not required and used for `imp_push` and `imp_extend_from_slice` methods of `ImpVec` since these methods do not require a `&mut self` reference. Therefore, the following code compiles and runs perfectly safely.
-//!
-//! ```rust
-//! use orx_imp_vec::prelude::*;
-//!
-//! let mut vec = ImpVec::new();
-//! vec.extend_from_slice(&[0, 1, 2, 3]);
-//!
-//! let ref_to_first = &vec[0];
-//! assert_eq!(ref_to_first, &0);
-//!
-//! vec.imp_push(4);
-//! assert_eq!(vec.len(), 5);
-//!
-//! vec.imp_extend_from_slice(&[6, 7]);
-//! assert_eq!(vec.len(), 7);
-//!
-//! assert_eq!(ref_to_first, &0);
-//! ```
-//!
-//! ## Contributing
-//!
-//! Contributions are welcome! If you notice an error, have a question or think something could be improved, please open an [issue](https://github.com/orxfun/orx-imp-vec/issues/new) or create a PR.
-//!
-//! ## License
-//!
-//! This library is licensed under MIT license. See LICENSE for details.
-
+#![doc = include_str!("../README.md")]
 #![warn(
     missing_docs,
     clippy::unwrap_in_result,
@@ -76,11 +10,15 @@
     clippy::missing_panics_doc,
     clippy::todo
 )]
+#![no_std]
+
+extern crate alloc;
 
 mod common_traits;
 mod imp_vec;
 mod new;
-/// Common traits, structs, enums.
-pub mod prelude;
 
 pub use imp_vec::ImpVec;
+pub use orx_fixed_vec::FixedVec;
+pub use orx_pinned_vec::PinnedVec;
+pub use orx_split_vec::{Doubling, Growth, Linear, Recursive, SplitVec};

--- a/src/new.rs
+++ b/src/new.rs
@@ -10,7 +10,7 @@ impl<T> ImpVec<T> {
     /// # Example
     ///
     /// ```rust
-    /// use orx_imp_vec::prelude::*;
+    /// use orx_imp_vec::*;
     ///
     /// let imp_vec: ImpVec<char> = ImpVec::new();
     /// assert!(imp_vec.is_empty());

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,0 @@
-pub use crate::ImpVec;
-pub use orx_fixed_vec::FixedVec;
-pub use orx_pinned_vec::*;
-pub use orx_split_vec::*;

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -1,4 +1,4 @@
-use orx_imp_vec::prelude::*;
+use orx_imp_vec::*;
 
 #[test]
 fn debug() {
@@ -8,10 +8,8 @@ fn debug() {
     }
 
     let imp_vec_str = format!("{:?}", &vec);
-
-    let pinned_vec = vec.into_inner();
-    let pinned_vec_str = format!("{:?}", &pinned_vec);
-    let expected_str = format!("ImpVec {{ pinned_vec: {} }}", pinned_vec_str);
+    let expected_str =
+        format!("[\"0\", \"1\", \"2\", \"3\", \"4\", \"5\", \"6\", \"7\", \"8\", \"9\"]");
 
     assert_eq!(imp_vec_str, expected_str);
 }

--- a/tests/deref_derefmut.rs
+++ b/tests/deref_derefmut.rs
@@ -1,4 +1,4 @@
-use orx_imp_vec::prelude::*;
+use orx_imp_vec::*;
 use std::ops::{Deref, DerefMut};
 
 #[test]

--- a/tests/eq.rs
+++ b/tests/eq.rs
@@ -1,5 +1,5 @@
 use orx_fixed_vec::FixedVec;
-use orx_imp_vec::prelude::*;
+use orx_imp_vec::*;
 
 #[test]
 fn eq() {

--- a/tests/from.rs
+++ b/tests/from.rs
@@ -1,4 +1,4 @@
-use orx_imp_vec::prelude::*;
+use orx_imp_vec::*;
 
 #[test]
 fn from() {

--- a/tests/from_iter.rs
+++ b/tests/from_iter.rs
@@ -1,4 +1,4 @@
-use orx_imp_vec::prelude::*;
+use orx_imp_vec::*;
 
 #[test]
 fn from_iter() {

--- a/tests/imp_vec.rs
+++ b/tests/imp_vec.rs
@@ -1,4 +1,4 @@
-use orx_imp_vec::prelude::*;
+use orx_imp_vec::*;
 
 #[test]
 fn new_default() {

--- a/tests/index.rs
+++ b/tests/index.rs
@@ -1,0 +1,27 @@
+pub use orx_imp_vec::*;
+
+#[test]
+fn index() {
+    let vec = ImpVec::new();
+    vec.imp_push(0);
+    vec.imp_extend_from_slice([1, 2, 3, 4].as_slice());
+
+    assert_eq!(&vec, [0, 1, 2, 3, 4].as_slice());
+
+    for i in 0..vec.len() {
+        assert_eq!(vec[i], i);
+    }
+}
+
+#[test]
+fn index_mut() {
+    let mut vec = ImpVec::new();
+    vec.imp_push(0);
+    vec.imp_extend_from_slice([1, 2, 3, 4].as_slice());
+
+    for i in 0..vec.len() {
+        vec[i] *= 2;
+    }
+
+    assert_eq!(&vec, [0, 2, 4, 6, 8].as_slice());
+}

--- a/tests/into_iter.rs
+++ b/tests/into_iter.rs
@@ -1,5 +1,5 @@
 use orx_fixed_vec::FixedVec;
-use orx_imp_vec::prelude::*;
+use orx_imp_vec::*;
 
 #[test]
 fn into_iter() {

--- a/tests/new.rs
+++ b/tests/new.rs
@@ -1,4 +1,4 @@
-use orx_imp_vec::prelude::*;
+use orx_imp_vec::*;
 
 #[test]
 fn new() {


### PR DESCRIPTION
* Crate is converted into no_std
* `Index` and `IndexMut` are implemented
* prelude module is removed, required dependencies are added to lib
* `Debug` implementation is revised to only inform about the elements rather than impl details.
* Examples are added.
* Motivation section of the docs is revised.